### PR TITLE
fix: parse error_union_type correctly

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -206,7 +206,6 @@ module.exports = grammar({
       optional($.address_space),
       optional($.link_section),
       optional($.calling_convention),
-      optional('!'),
       field('type', choice($.type_expression, $.if_type_expression, $.comptime_type_expression)),
     ),
 
@@ -692,7 +691,7 @@ module.exports = grammar({
     )),
 
     error_union_type: $ => prec.right(2, seq(
-      field('error', $.type_expression),
+      optional(field('error', $.type_expression)),
       '!',
       field('ok', $.type_expression),
     )),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -836,18 +836,6 @@
           ]
         },
         {
-          "type": "CHOICE",
-          "members": [
-            {
-              "type": "STRING",
-              "value": "!"
-            },
-            {
-              "type": "BLANK"
-            }
-          ]
-        },
-        {
           "type": "FIELD",
           "name": "type",
           "content": {
@@ -4938,12 +4926,20 @@
         "type": "SEQ",
         "members": [
           {
-            "type": "FIELD",
-            "name": "error",
-            "content": {
-              "type": "SYMBOL",
-              "name": "type_expression"
-            }
+            "type": "CHOICE",
+            "members": [
+              {
+                "type": "FIELD",
+                "name": "error",
+                "content": {
+                  "type": "SYMBOL",
+                  "name": "type_expression"
+                }
+              },
+              {
+                "type": "BLANK"
+              }
+            ]
           },
           {
             "type": "STRING",

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1293,7 +1293,7 @@
     "fields": {
       "error": {
         "multiple": false,
-        "required": true,
+        "required": false,
         "types": [
           {
             "type": "type_expression",


### PR DESCRIPTION
closes: https://github.com/tree-sitter-grammars/tree-sitter-zig/issues/1#issue-2531569518

https://ziglang.org/documentation/master/#Error-Union-Type

This should be more true to zig grammar `!` probably doesn't belong in `_function_prototype` at all. The error set can be inferred so the left side should be optional.

current grammar expects something like this for error union type:

```zig
fn example() anyerror!std.ArrayList(struct {
```

but when it encounters this:
```zig
fn example() !std.ArrayList(struct {
```

It enters an infinite error recovery loop (which ends up crashing nvim for me)

---

new output of `tree-sitter parse` (for incomplete definition with error)
```
(source_file [0, 0] - [1, 0]
  (ERROR [0, 0] - [0, 36]
    (field_expression [0, 0] - [0, 27]
      object: (function_signature [0, 0] - [0, 17]
        name: (identifier [0, 3] - [0, 10])
        (parameters [0, 10] - [0, 12])
        type: (error_union_type [0, 13] - [0, 17]
          ok: (identifier [0, 14] - [0, 17])))
      member: (identifier [0, 18] - [0, 27]))))
```