### PR TITLE
feat: expose nodes for documentation comments `///` and `//!`

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Zig grammar for [tree-sitter](https://github.com/tree-sitter/tree-sitter).
 
 ## References
 
-- [Zig Grammar](https://github.com/ziglang/zig-spec/blob/master/grammar/grammar.y)
+- [Zig Grammar](https://github.com/ziglang/zig-spec/blob/master/grammar/grammar.peg)
 
 [ci]: https://img.shields.io/github/actions/workflow/status/tree-sitter-grammars/tree-sitter-zig/ci.yml?logo=github&label=CI
 [discord]: https://img.shields.io/discord/1063097320771698699?logo=discord&label=discord

--- a/bindings/go/binding.go
+++ b/bindings/go/binding.go
@@ -2,6 +2,7 @@ package tree_sitter_zig
 
 // #cgo CFLAGS: -std=c11 -fPIC
 // #include "../../src/parser.c"
+// #include "../../src/scanner.c"
 import "C"
 
 import "unsafe"

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -11,5 +11,9 @@ fn main() {
     c_config.file(&parser_path);
     println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+
     c_config.compile("tree-sitter-zig");
 }

--- a/grammar.js
+++ b/grammar.js
@@ -54,6 +54,8 @@ const builtinTypes = [
 module.exports = grammar({
   name: 'zig',
 
+  externals: ($) => [$.doc_comment_content, $._error_sentinel],
+
   conflicts: $ => [
     [$.for_expression],
     [$.while_expression],
@@ -67,6 +69,8 @@ module.exports = grammar({
 
   extras: $ => [
     $.comment,
+    $.container_doc_comment,
+    $.doc_comment,
     /\s/,
   ],
 
@@ -860,7 +864,19 @@ module.exports = grammar({
       'false',
     ),
 
-    comment: _ => token(seq('//', /.*/)),
+    /* Comments */
+
+    container_doc_comment: ($) => prec(3, seq('//!', $.doc_comment_content)),
+
+    doc_comment: ($) => prec(2, seq('///', $.doc_comment_content)),
+
+    comment: ($) =>
+      choice(
+        prec(1, seq('//', /.*/)),
+
+        // `//// ...` looks like a `container_doc_comment`, but it is not
+        prec(4, seq('////', /.*/)),
+      ),
   },
 });
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -6494,27 +6494,92 @@
         }
       ]
     },
-    "comment": {
-      "type": "TOKEN",
+    "container_doc_comment": {
+      "type": "PREC",
+      "value": 3,
       "content": {
         "type": "SEQ",
         "members": [
           {
             "type": "STRING",
-            "value": "//"
+            "value": "//!"
           },
           {
-            "type": "PATTERN",
-            "value": ".*"
+            "type": "SYMBOL",
+            "name": "doc_comment_content"
           }
         ]
       }
+    },
+    "doc_comment": {
+      "type": "PREC",
+      "value": 2,
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "///"
+          },
+          {
+            "type": "SYMBOL",
+            "name": "doc_comment_content"
+          }
+        ]
+      }
+    },
+    "comment": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "PREC",
+          "value": 1,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "//"
+              },
+              {
+                "type": "PATTERN",
+                "value": ".*"
+              }
+            ]
+          }
+        },
+        {
+          "type": "PREC",
+          "value": 4,
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": "////"
+              },
+              {
+                "type": "PATTERN",
+                "value": ".*"
+              }
+            ]
+          }
+        }
+      ]
     }
   },
   "extras": [
     {
       "type": "SYMBOL",
       "name": "comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "container_doc_comment"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "doc_comment"
     },
     {
       "type": "PATTERN",
@@ -6557,7 +6622,16 @@
       }
     ]
   ],
-  "externals": [],
+  "externals": [
+    {
+      "type": "SYMBOL",
+      "name": "doc_comment_content"
+    },
+    {
+      "type": "SYMBOL",
+      "name": "_error_sentinel"
+    }
+  ],
   "inline": [
     "_reserved_identifier"
   ],
@@ -6566,5 +6640,6 @@
     "expression",
     "type_expression",
     "primary_type_expression"
-  ]
+  ],
+  "reserved": {}
 }

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -993,6 +993,11 @@
     }
   },
   {
+    "type": "comment",
+    "named": true,
+    "fields": {}
+  },
+  {
     "type": "comptime_declaration",
     "named": true,
     "fields": {},
@@ -1059,6 +1064,21 @@
       "types": [
         {
           "type": "type_expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "container_doc_comment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "doc_comment_content",
           "named": true
         }
       ]
@@ -1180,6 +1200,21 @@
       "types": [
         {
           "type": "expression",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "doc_comment",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "doc_comment_content",
           "named": true
         }
       ]
@@ -2728,6 +2763,22 @@
     "named": false
   },
   {
+    "type": "//",
+    "named": false
+  },
+  {
+    "type": "//!",
+    "named": false
+  },
+  {
+    "type": "///",
+    "named": false
+  },
+  {
+    "type": "////",
+    "named": false
+  },
+  {
     "type": "/=",
     "named": false
   },
@@ -2924,10 +2975,6 @@
     "named": true
   },
   {
-    "type": "comment",
-    "named": true
-  },
-  {
     "type": "comptime",
     "named": false
   },
@@ -2950,6 +2997,10 @@
   {
     "type": "defer",
     "named": false
+  },
+  {
+    "type": "doc_comment_content",
+    "named": true
   },
   {
     "type": "else",

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -1,0 +1,37 @@
+#include <tree_sitter/parser.h>
+
+enum TokenType {
+  DOC_COMMENT_CONTENT,
+  ERROR_SENTINEL
+};
+
+void * tree_sitter_zig_external_scanner_create() {return NULL;}
+void tree_sitter_zig_external_scanner_destroy(void * payload) {}
+unsigned tree_sitter_zig_external_scanner_serialize(void * payload, char * buffer) {return 0;}
+void tree_sitter_zig_external_scanner_deserialize(void * payload, const char * buffer, unsigned length) {}
+
+bool tree_sitter_zig_external_scanner_scan(void * payload, TSLexer *lexer, const bool * valid_symbols) {
+  // without this, error recovery for comments is much worse.
+  // a single `/` marks the rest of the file as a comment
+  if (valid_symbols[ERROR_SENTINEL]) {
+      return false;
+  }
+    
+  if (valid_symbols[DOC_COMMENT_CONTENT]) {
+    lexer->result_symbol = DOC_COMMENT_CONTENT;
+    while (true) {
+        if (lexer->eof(lexer)) {
+            return true;
+        }
+        if (lexer->lookahead == '\n') {
+            // including the line ending in doc
+            // comments is necessary for markdown injections
+            lexer->advance(lexer, false);
+            return true;
+        }
+        lexer->advance(lexer, false);
+    }
+  }
+  
+  return false;
+}

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -18,6 +18,12 @@ typedef uint16_t TSStateId;
 typedef uint16_t TSSymbol;
 typedef uint16_t TSFieldId;
 typedef struct TSLanguage TSLanguage;
+typedef struct TSLanguageMetadata TSLanguageMetadata;
+typedef struct TSLanguageMetadata {
+  uint8_t major_version;
+  uint8_t minor_version;
+  uint8_t patch_version;
+} TSLanguageMetadata;
 #endif
 
 typedef struct {
@@ -26,10 +32,11 @@ typedef struct {
   bool inherited;
 } TSFieldMapEntry;
 
+// Used to index the field and supertype maps.
 typedef struct {
   uint16_t index;
   uint16_t length;
-} TSFieldMapSlice;
+} TSMapSlice;
 
 typedef struct {
   bool visible;
@@ -79,6 +86,12 @@ typedef struct {
   uint16_t external_lex_state;
 } TSLexMode;
 
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+  uint16_t reserved_word_set_id;
+} TSLexerMode;
+
 typedef union {
   TSParseAction action;
   struct {
@@ -93,7 +106,7 @@ typedef struct {
 } TSCharacterRange;
 
 struct TSLanguage {
-  uint32_t version;
+  uint32_t abi_version;
   uint32_t symbol_count;
   uint32_t alias_count;
   uint32_t token_count;
@@ -109,13 +122,13 @@ struct TSLanguage {
   const TSParseActionEntry *parse_actions;
   const char * const *symbol_names;
   const char * const *field_names;
-  const TSFieldMapSlice *field_map_slices;
+  const TSMapSlice *field_map_slices;
   const TSFieldMapEntry *field_map_entries;
   const TSSymbolMetadata *symbol_metadata;
   const TSSymbol *public_symbol_map;
   const uint16_t *alias_map;
   const TSSymbol *alias_sequences;
-  const TSLexMode *lex_modes;
+  const TSLexerMode *lex_modes;
   bool (*lex_fn)(TSLexer *, TSStateId);
   bool (*keyword_lex_fn)(TSLexer *, TSStateId);
   TSSymbol keyword_capture_token;
@@ -129,15 +142,23 @@ struct TSLanguage {
     void (*deserialize)(void *, const char *, unsigned);
   } external_scanner;
   const TSStateId *primary_state_ids;
+  const char *name;
+  const TSSymbol *reserved_words;
+  uint16_t max_reserved_word_set_size;
+  uint32_t supertype_count;
+  const TSSymbol *supertype_symbols;
+  const TSMapSlice *supertype_map_slices;
+  const TSSymbol *supertype_map_entries;
+  TSLanguageMetadata metadata;
 };
 
-static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
+static inline bool set_contains(const TSCharacterRange *ranges, uint32_t len, int32_t lookahead) {
   uint32_t index = 0;
   uint32_t size = len - index;
   while (size > 1) {
     uint32_t half_size = size / 2;
     uint32_t mid_index = index + half_size;
-    TSCharacterRange *range = &ranges[mid_index];
+    const TSCharacterRange *range = &ranges[mid_index];
     if (lookahead >= range->start && lookahead <= range->end) {
       return true;
     } else if (lookahead > range->end) {
@@ -145,7 +166,7 @@ static inline bool set_contains(TSCharacterRange *ranges, uint32_t len, int32_t 
     }
     size -= half_size;
   }
-  TSCharacterRange *range = &ranges[index];
+  const TSCharacterRange *range = &ranges[index];
   return (lookahead >= range->start && lookahead <= range->end);
 }
 

--- a/test/corpus/comment.txt
+++ b/test/corpus/comment.txt
@@ -1,0 +1,24 @@
+================================================================================
+Comments
+================================================================================
+
+///// regular comment
+
+//// regular comment
+
+//! module doc comment
+
+/// statement doc comment
+
+// regular comment
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (comment)
+  (comment)
+  (container_doc_comment
+    (doc_comment_content))
+  (doc_comment
+    (doc_comment_content))
+  (comment))


### PR DESCRIPTION
This PR allows markdown injection for the documentation comments:

![image](https://github.com/user-attachments/assets/29a9fd35-7539-4aa8-a3b7-bbc9522280e2)
