### PR TITLE
fix: assignments are not expressions

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -58,8 +58,7 @@
 ; Fields
 
 (field_initializer
-  .
-  (identifier) @variable.member)
+  name: (identifier) @variable.member)
 
 (field_expression
   (_)
@@ -67,12 +66,6 @@
 
 (container_field
   name: (identifier) @variable.member)
-
-(initializer_list
-  (assignment_expression
-      left: (field_expression
-              .
-              member: (identifier) @variable.member)))
 
 ; Functions
 

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -460,81 +460,8 @@
                   "type": "SEQ",
                   "members": [
                     {
-                      "type": "CHOICE",
-                      "members": [
-                        {
-                          "type": "STRING",
-                          "value": "="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "*="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "*%="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "*|="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "/="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "%="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "+="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "+%="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "+|="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "-="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "-%="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "-|="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "<<="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "<<|="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": ">>="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "&="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "^="
-                        },
-                        {
-                          "type": "STRING",
-                          "value": "|="
-                        }
-                      ]
+                      "type": "SYMBOL",
+                      "name": "assignment_operator"
                     },
                     {
                       "type": "SYMBOL",
@@ -1613,8 +1540,26 @@
             ]
           },
           {
-            "type": "SYMBOL",
-            "name": "expression_statement"
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "assignment_expression"
+                  }
+                ]
+              },
+              {
+                "type": "STRING",
+                "value": ";"
+              }
+            ]
           }
         ]
       }
@@ -1997,8 +1942,17 @@
                   "value": "("
                 },
                 {
-                  "type": "SYMBOL",
-                  "name": "expression"
+                  "type": "CHOICE",
+                  "members": [
+                    {
+                      "type": "SYMBOL",
+                      "name": "expression"
+                    },
+                    {
+                      "type": "SYMBOL",
+                      "name": "assignment_expression"
+                    }
+                  ]
                 },
                 {
                   "type": "STRING",
@@ -2048,8 +2002,17 @@
               "type": "FIELD",
               "name": "body",
               "content": {
-                "type": "SYMBOL",
-                "name": "expression"
+                "type": "CHOICE",
+                "members": [
+                  {
+                    "type": "SYMBOL",
+                    "name": "expression"
+                  },
+                  {
+                    "type": "SYMBOL",
+                    "name": "assignment_expression"
+                  }
+                ]
               }
             },
             {
@@ -2263,10 +2226,6 @@
           {
             "type": "SYMBOL",
             "name": "while_expression"
-          },
-          {
-            "type": "SYMBOL",
-            "name": "assignment_expression"
           },
           {
             "type": "SYMBOL",
@@ -2880,110 +2839,60 @@
       }
     },
     "assignment_expression": {
-      "type": "PREC_RIGHT",
-      "value": 0,
-      "content": {
-        "type": "SEQ",
-        "members": [
-          {
-            "type": "FIELD",
-            "name": "left",
-            "content": {
-              "type": "SYMBOL",
-              "name": "expression"
-            }
-          },
-          {
-            "type": "FIELD",
-            "name": "operator",
-            "content": {
-              "type": "CHOICE",
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SEQ",
               "members": [
+                {
+                  "type": "SYMBOL",
+                  "name": "assignment_operator"
+                },
+                {
+                  "type": "SYMBOL",
+                  "name": "expression"
+                }
+              ]
+            },
+            {
+              "type": "SEQ",
+              "members": [
+                {
+                  "type": "REPEAT1",
+                  "content": {
+                    "type": "SEQ",
+                    "members": [
+                      {
+                        "type": "STRING",
+                        "value": ","
+                      },
+                      {
+                        "type": "SYMBOL",
+                        "name": "expression"
+                      }
+                    ]
+                  }
+                },
                 {
                   "type": "STRING",
                   "value": "="
                 },
                 {
-                  "type": "STRING",
-                  "value": "*="
-                },
-                {
-                  "type": "STRING",
-                  "value": "*%="
-                },
-                {
-                  "type": "STRING",
-                  "value": "*|="
-                },
-                {
-                  "type": "STRING",
-                  "value": "/="
-                },
-                {
-                  "type": "STRING",
-                  "value": "%="
-                },
-                {
-                  "type": "STRING",
-                  "value": "+="
-                },
-                {
-                  "type": "STRING",
-                  "value": "+%="
-                },
-                {
-                  "type": "STRING",
-                  "value": "+|="
-                },
-                {
-                  "type": "STRING",
-                  "value": "-="
-                },
-                {
-                  "type": "STRING",
-                  "value": "-%="
-                },
-                {
-                  "type": "STRING",
-                  "value": "-|="
-                },
-                {
-                  "type": "STRING",
-                  "value": "<<="
-                },
-                {
-                  "type": "STRING",
-                  "value": "<<|="
-                },
-                {
-                  "type": "STRING",
-                  "value": ">>="
-                },
-                {
-                  "type": "STRING",
-                  "value": "&="
-                },
-                {
-                  "type": "STRING",
-                  "value": "^="
-                },
-                {
-                  "type": "STRING",
-                  "value": "|="
+                  "type": "SYMBOL",
+                  "name": "expression"
                 }
               ]
             }
-          },
-          {
-            "type": "FIELD",
-            "name": "right",
-            "content": {
-              "type": "SYMBOL",
-              "name": "expression"
-            }
-          }
-        ]
-      }
+          ]
+        }
+      ]
     },
     "unary_expression": {
       "type": "PREC_LEFT",
@@ -4347,6 +4256,15 @@
             {
               "type": "SYMBOL",
               "name": "expression"
+            },
+            {
+              "type": "ALIAS",
+              "content": {
+                "type": "SYMBOL",
+                "name": "_single_assignment_expression"
+              },
+              "named": true,
+              "value": "assignment_expression"
             }
           ]
         }
@@ -4469,6 +4387,23 @@
               "value": "else"
             }
           ]
+        }
+      ]
+    },
+    "_single_assignment_expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "assignment_operator"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
         }
       ]
     },
@@ -5395,8 +5330,12 @@
           "value": "."
         },
         {
-          "type": "SYMBOL",
-          "name": "identifier"
+          "type": "FIELD",
+          "name": "name",
+          "content": {
+            "type": "SYMBOL",
+            "name": "identifier"
+          }
         },
         {
           "type": "STRING",
@@ -5605,6 +5544,83 @@
         {
           "type": "STRING",
           "value": ")"
+        }
+      ]
+    },
+    "assignment_operator": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "="
+        },
+        {
+          "type": "STRING",
+          "value": "*="
+        },
+        {
+          "type": "STRING",
+          "value": "*%="
+        },
+        {
+          "type": "STRING",
+          "value": "*|="
+        },
+        {
+          "type": "STRING",
+          "value": "/="
+        },
+        {
+          "type": "STRING",
+          "value": "%="
+        },
+        {
+          "type": "STRING",
+          "value": "+="
+        },
+        {
+          "type": "STRING",
+          "value": "+%="
+        },
+        {
+          "type": "STRING",
+          "value": "+|="
+        },
+        {
+          "type": "STRING",
+          "value": "-="
+        },
+        {
+          "type": "STRING",
+          "value": "-%="
+        },
+        {
+          "type": "STRING",
+          "value": "-|="
+        },
+        {
+          "type": "STRING",
+          "value": "<<="
+        },
+        {
+          "type": "STRING",
+          "value": "<<|="
+        },
+        {
+          "type": "STRING",
+          "value": ">>="
+        },
+        {
+          "type": "STRING",
+          "value": "&="
+        },
+        {
+          "type": "STRING",
+          "value": "^="
+        },
+        {
+          "type": "STRING",
+          "value": "|="
         }
       ]
     },
@@ -6554,6 +6570,16 @@
       {
         "type": "SYMBOL",
         "name": "type_expression"
+      }
+    ],
+    [
+      {
+        "type": "SYMBOL",
+        "name": "_variable_declaration_expression_statement"
+      },
+      {
+        "type": "SYMBOL",
+        "name": "assignment_expression"
       }
     ]
   ],

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -8,10 +8,6 @@
         "named": true
       },
       {
-        "type": "assignment_expression",
-        "named": true
-      },
-      {
         "type": "async_expression",
         "named": true
       },
@@ -507,106 +503,26 @@
   {
     "type": "assignment_expression",
     "named": true,
-    "fields": {
-      "left": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "expression",
-            "named": true
-          }
-        ]
-      },
-      "operator": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "%=",
-            "named": false
-          },
-          {
-            "type": "&=",
-            "named": false
-          },
-          {
-            "type": "*%=",
-            "named": false
-          },
-          {
-            "type": "*=",
-            "named": false
-          },
-          {
-            "type": "*|=",
-            "named": false
-          },
-          {
-            "type": "+%=",
-            "named": false
-          },
-          {
-            "type": "+=",
-            "named": false
-          },
-          {
-            "type": "+|=",
-            "named": false
-          },
-          {
-            "type": "-%=",
-            "named": false
-          },
-          {
-            "type": "-=",
-            "named": false
-          },
-          {
-            "type": "-|=",
-            "named": false
-          },
-          {
-            "type": "/=",
-            "named": false
-          },
-          {
-            "type": "<<=",
-            "named": false
-          },
-          {
-            "type": "<<|=",
-            "named": false
-          },
-          {
-            "type": "=",
-            "named": false
-          },
-          {
-            "type": ">>=",
-            "named": false
-          },
-          {
-            "type": "^=",
-            "named": false
-          },
-          {
-            "type": "|=",
-            "named": false
-          }
-        ]
-      },
-      "right": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "expression",
-            "named": true
-          }
-        ]
-      }
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "assignment_operator",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        }
+      ]
     }
+  },
+  {
+    "type": "assignment_operator",
+    "named": true,
+    "fields": {}
   },
   {
     "type": "async_expression",
@@ -1031,7 +947,7 @@
       "required": true,
       "types": [
         {
-          "type": "block",
+          "type": "assignment_expression",
           "named": true
         },
         {
@@ -1039,7 +955,7 @@
           "named": true
         },
         {
-          "type": "expression_statement",
+          "type": "expression",
           "named": true
         },
         {
@@ -1156,7 +1072,7 @@
       "required": true,
       "types": [
         {
-          "type": "block",
+          "type": "assignment_expression",
           "named": true
         },
         {
@@ -1164,7 +1080,7 @@
           "named": true
         },
         {
-          "type": "expression_statement",
+          "type": "expression",
           "named": true
         }
       ]
@@ -1259,7 +1175,7 @@
       "required": true,
       "types": [
         {
-          "type": "block",
+          "type": "assignment_expression",
           "named": true
         },
         {
@@ -1267,7 +1183,7 @@
           "named": true
         },
         {
-          "type": "expression_statement",
+          "type": "expression",
           "named": true
         },
         {
@@ -1377,17 +1293,24 @@
   {
     "type": "field_initializer",
     "named": true,
-    "fields": {},
+    "fields": {
+      "name": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "identifier",
+            "named": true
+          }
+        ]
+      }
+    },
     "children": {
-      "multiple": true,
+      "multiple": false,
       "required": true,
       "types": [
         {
           "type": "expression",
-          "named": true
-        },
-        {
-          "type": "identifier",
           "named": true
         }
       ]
@@ -1424,6 +1347,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "assignment_expression",
+            "named": true
+          },
           {
             "type": "block_expression",
             "named": true
@@ -1642,6 +1569,10 @@
         "required": true,
         "types": [
           {
+            "type": "assignment_expression",
+            "named": true
+          },
+          {
             "type": "block_expression",
             "named": true
           },
@@ -1852,7 +1783,7 @@
       "required": true,
       "types": [
         {
-          "type": "block",
+          "type": "assignment_expression",
           "named": true
         },
         {
@@ -1860,7 +1791,7 @@
           "named": true
         },
         {
-          "type": "expression_statement",
+          "type": "expression",
           "named": true
         }
       ]
@@ -2249,7 +2180,7 @@
       "required": true,
       "types": [
         {
-          "type": "block",
+          "type": "assignment_expression",
           "named": true
         },
         {
@@ -2257,7 +2188,7 @@
           "named": true
         },
         {
-          "type": "expression_statement",
+          "type": "expression",
           "named": true
         }
       ]
@@ -2271,6 +2202,10 @@
       "multiple": true,
       "required": true,
       "types": [
+        {
+          "type": "assignment_expression",
+          "named": true
+        },
         {
           "type": "expression",
           "named": true
@@ -2471,6 +2406,10 @@
           "named": true
         },
         {
+          "type": "assignment_operator",
+          "named": true
+        },
+        {
           "type": "byte_alignment",
           "named": true
         },
@@ -2513,6 +2452,10 @@
       "required": true,
       "types": [
         {
+          "type": "assignment_expression",
+          "named": true
+        },
+        {
           "type": "block_label",
           "named": true
         },
@@ -2535,6 +2478,10 @@
         "multiple": false,
         "required": true,
         "types": [
+          {
+            "type": "assignment_expression",
+            "named": true
+          },
           {
             "type": "block_expression",
             "named": true
@@ -2560,6 +2507,10 @@
       "multiple": true,
       "required": false,
       "types": [
+        {
+          "type": "assignment_expression",
+          "named": true
+        },
         {
           "type": "else_clause",
           "named": true

--- a/test/corpus/expressions.txt
+++ b/test/corpus/expressions.txt
@@ -1,0 +1,72 @@
+===============================================================================
+Assignment expressions
+===============================================================================
+
+test {
+  defer foo += 123;
+  switch(foo) {
+    1...3 => main(),
+    321 => foo -= 123,
+    else => bar = foo == 0,
+  }
+  if(true) in, out = .{0, 0} else in >>= 8;
+  while(i < 10) : (i += 2) i -= 1;
+}
+
+-------------------------------------------------------------------------------
+
+(source_file
+  (test_declaration
+    (block
+      (defer_statement
+        (assignment_expression
+          (identifier)
+          (assignment_operator)
+          (integer)))
+      (switch_expression
+        (identifier)
+        (switch_case
+          (integer)
+          (integer)
+          (call_expression
+            (identifier)))
+        (switch_case
+          (integer)
+          (assignment_expression
+            (identifier)
+            (assignment_operator)
+            (integer)))
+        (switch_case
+          (assignment_expression
+            (identifier)
+            (assignment_operator)
+            (binary_expression
+              (identifier)
+              (integer)))))
+      (if_statement
+        (boolean)
+        (assignment_expression
+          (identifier)
+          (identifier)
+          (anonymous_struct_initializer
+            (initializer_list
+              (integer)
+              (integer))))
+        (else_clause
+          (variable_declaration
+            (identifier)
+            (assignment_operator)
+            (integer))))
+      (labeled_statement
+        (while_statement
+          (binary_expression
+            (identifier)
+            (integer))
+          (assignment_expression
+            (identifier)
+            (assignment_operator)
+            (integer))
+          (assignment_expression
+            (identifier)
+            (assignment_operator)
+            (integer)))))))

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -1,0 +1,74 @@
+================================================================================
+Initializers
+================================================================================
+
+const init = Struct{
+  .foo = bar,
+  .@"5" = 2 + 2,
+};
+fn print123() void {
+  print(.{1, 2, 3});
+}
+fn init(self: *SomeStruct) void {
+  self.* = .{
+    .foo = bar,
+    .@"5" = 2 + 2,
+  };
+}
+
+-------------------------------------------------------------------------------
+
+(source_file
+  (variable_declaration
+    (identifier)
+    (struct_initializer
+      (identifier)
+      (initializer_list
+        (field_initializer
+          (identifier)
+          (identifier))
+        (field_initializer
+          (identifier
+            (string
+              (string_content)))
+          (binary_expression
+            (integer)
+                (integer))))))
+  (function_declaration
+    (identifier)
+    (parameters)
+    (builtin_type)
+    (block
+      (expression_statement
+        (call_expression
+          (identifier)
+          (anonymous_struct_initializer
+            (initializer_list
+              (integer)
+              (integer)
+              (integer)))))))
+  (function_declaration
+    (identifier)
+    (parameters
+      (parameter
+        (identifier)
+        (pointer_type
+          (identifier))))
+    (builtin_type)
+    (block
+      (variable_declaration
+        (dereference_expression
+          (identifier))
+        (assignment_operator)
+        (anonymous_struct_initializer
+          (initializer_list
+            (field_initializer
+              (identifier)
+              (identifier))
+            (field_initializer
+              (identifier
+                (string
+                  (string_content)))
+              (binary_expression
+                (integer)
+                (integer)))))))))


### PR DESCRIPTION
Assignments in Zig are not expressions in general and are allowed to be used as such only in certain places. There is an open proposal ([ziglang/zig#11805](https://github.com/ziglang/zig/issues/11805)) to change this but it's not going anywhere at the moment. The exact conditions placed on the use of assignment expressions can be seen in the `AssignExpr` and `SingleAssignExpr` rules in [Zig's grammar](https://ziglang.org/documentation/master/#Grammar). This PR attempts to make this Tree-sitter grammar truer to this part of the language specification.

This change is motivated by field initializers in initializer lists being wrongly parsed as `assignment_expression` instead of `field_initializer` in the old grammar. It fixes that bug.