### PR TITLE
Updating build.zig.zon for recent versions of Zig language

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,10 +1,13 @@
 .{
-    .name = "tree-sitter-zig",
+    .name = .tree_sitter_zig,
+    .fingerprint = 0xb3d00960f008046e,
     .version = "1.1.2",
-    .dependencies = .{ .@"tree-sitter" = .{
-        .url = "https://github.com/tree-sitter/zig-tree-sitter/archive/refs/tags/v0.25.0.tar.gz",
-        .hash = "12201a8d5e840678bbbf5128e605519c4024af422295d68e2ba2090e675328e5811d",
-    } },
+    .dependencies = .{
+        .@"tree-sitter" = .{
+            .url = "git+https://github.com/tree-sitter/zig-tree-sitter.git#b4b72c903e69998fc88e27e154a5e3cc9166551b",
+            .hash = "tree_sitter-0.25.0-8heIf51vAQConvVIgvm-9mVIbqh7yabZYqPXfOpS3YoG",
+        },
+    },
     .paths = .{
         "build.zig",
         "build.zig.zon",


### PR DESCRIPTION
see [this issue](https://github.com/tree-sitter-grammars/tree-sitter-zig/issues/14).