### PR TITLE
add fingerprint

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
     .name = .tree_sitter_zig,
     .version = "1.1.2",
+    .fingerprint = 0xb3d00960021704dd,
     .dependencies = .{
         .tree_sitter = .{
             .url = "git+https://github.com/tree-sitter/zig-tree-sitter#b4b72c903e69998fc88e27e154a5e3cc9166551b",


### PR DESCRIPTION
Fixes #28

Zig added fingerprint in build.zig.zon, without it I get the following error:

``
$zig fetch --save git+https://github.com/tree-sitter-grammars/tree-sitter-zig
``
``
zig-pkg/.tmp-d27b507b1129fdbf/build.zig.zon:1:2: error: missing top-level 'fingerprint' field; suggested value: 0xb3d00960bb12f7a6
.{
 ^
``