### PR TITLE
Upgrade to zig 0.16.0

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,7 +1,12 @@
 const std = @import("std");
 
 pub fn build(b: *std.Build) !void {
-    const target = b.standardTargetOptions(.{});
+    // Pin glibc 2.17 so Zig uses its bundled crt1.o instead of the system's.
+    // GCC 15's crt1.o has .sframe sections with R_X86_64_PC64 relocations that
+    // Zig's self-hosted linker doesn't support yet.
+    const target = b.standardTargetOptions(.{
+        .default_target = .{ .glibc_version = .{ .major = 2, .minor = 17, .patch = 0 } },
+    });
     const optimize = b.standardOptimizeOption(.{});
 
     const shared = b.option(bool, "build-shared", "Build a shared library") orelse true;
@@ -20,12 +25,12 @@ pub fn build(b: *std.Build) !void {
         }),
     });
 
-    lib.addCSourceFile(.{
+    lib.root_module.addCSourceFile(.{
         .file = b.path("src/parser.c"),
         .flags = &.{"-std=c11"},
     });
     if (fileExists(b, "src/scanner.c")) {
-        lib.addCSourceFile(.{
+        lib.root_module.addCSourceFile(.{
             .file = b.path("src/scanner.c"),
             .flags = &.{"-std=c11"},
         });
@@ -38,7 +43,7 @@ pub fn build(b: *std.Build) !void {
         lib.root_module.addCMacro("TREE_SITTER_DEBUG", "");
     }
 
-    lib.addIncludePath(b.path("src"));
+    lib.root_module.addIncludePath(b.path("src"));
 
     b.installArtifact(lib);
     b.installFile("src/node-types.json", "node-types.json");
@@ -68,26 +73,72 @@ pub fn build(b: *std.Build) !void {
     });
     tests.root_module.addImport(library_name, module);
 
-    // HACK: fetch tree-sitter dependency only when testing this module
-    if (b.pkg_hash.len == 0) {
-        var args = try std.process.argsWithAllocator(b.allocator);
-        defer args.deinit();
-        while (args.next()) |a| {
-            if (std.mem.eql(u8, a, "test")) {
-                const ts_dep = b.lazyDependency("tree_sitter", .{}) orelse continue;
-                tests.root_module.addImport("tree-sitter", ts_dep.module("tree-sitter"));
-                break;
-            }
+    if (isStepRequested(b, "test")) {
+        if (b.lazyDependency("tree_sitter", .{})) |ts_dep| {
+            tests.root_module.addImport("tree-sitter", ts_dep.module("tree_sitter"));
         }
     }
 
     const run_tests = b.addRunArtifact(tests);
+
     const test_step = b.step("test", "Run unit tests");
     test_step.dependOn(&run_tests.step);
 }
 
 inline fn fileExists(b: *std.Build, filename: []const u8) bool {
     const dir = b.build_root.handle;
-    dir.access(filename, .{}) catch return false;
+    dir.access(b.graph.io, filename, .{}) catch return false;
     return true;
+}
+
+// lazyDependency must be called during build() (config phase), not in a step's make().
+// Zig 0.16 removed std.process.argsWithAllocator and provides no build API for querying
+// which steps were requested, so we read process args directly per platform.
+fn isStepRequested(b: *std.Build, step_name: []const u8) bool {
+    if (b.pkg_hash.len != 0) return false; // skip when built as a dependency
+    const builtin = @import("builtin");
+    if (comptime builtin.os.tag == .linux) {
+        return isStepRequestedLinux(b, step_name);
+    } else if (comptime builtin.os.tag.isDarwin()) {
+        return isStepRequestedDarwin(step_name);
+    } else if (comptime builtin.os.tag == .windows) {
+        return isStepRequestedWindows(b, step_name);
+    } else {
+        return true; // conservative: assume requested on unknown platforms
+    }
+}
+
+fn isStepRequestedLinux(b: *std.Build, step_name: []const u8) bool {
+    const file = std.Io.Dir.openFileAbsolute(b.graph.io, "/proc/self/cmdline", .{}) catch return true;
+    defer file.close(b.graph.io);
+    var buf: [4096]u8 = undefined;
+    const len = file.readPositionalAll(b.graph.io, &buf, 0) catch return true;
+    var it = std.mem.tokenizeScalar(u8, buf[0..len], 0);
+    while (it.next()) |arg| {
+        if (std.mem.eql(u8, arg, step_name)) return true;
+    }
+    return false;
+}
+
+fn isStepRequestedDarwin(step_name: []const u8) bool {
+    const ns = struct {
+        extern "c" fn _NSGetArgc() *c_int;
+        extern "c" fn _NSGetArgv() *[*][*:0]u8;
+    };
+    const argc: usize = @intCast(ns._NSGetArgc().*);
+    const argv: [*][*:0]u8 = ns._NSGetArgv().*;
+    for (0..argc) |i| {
+        if (std.mem.eql(u8, std.mem.span(argv[i]), step_name)) return true;
+    }
+    return false;
+}
+
+fn isStepRequestedWindows(b: *std.Build, step_name: []const u8) bool {
+    const cmd_line = std.os.windows.peb().ProcessParameters.CommandLine.slice();
+    var it = std.process.Args.Iterator.Windows.init(b.allocator, cmd_line) catch return true;
+    defer it.deinit();
+    while (it.next()) |arg| {
+        if (std.mem.eql(u8, arg, step_name)) return true;
+    }
+    return false;
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,10 +1,11 @@
 .{
     .name = .tree_sitter_zig,
     .version = "1.1.2",
+    .fingerprint = 0xb3d009607f2977ec,
     .dependencies = .{
         .tree_sitter = .{
-            .url = "git+https://github.com/tree-sitter/zig-tree-sitter#b4b72c903e69998fc88e27e154a5e3cc9166551b",
-            .hash = "tree_sitter-0.25.0-8heIf51vAQConvVIgvm-9mVIbqh7yabZYqPXfOpS3YoG",
+            .url = "git+https://github.com/tree-sitter/zig-tree-sitter#0cf58172e61f6fdd16f681cde42b4acb531a23db",
+            .hash = "tree_sitter-0.26.0-8heIf3CaAQDeVTQc0DMSBhbQAEx5aF-dTen4_LPxMgrv",
             .lazy = true,
         },
     },


### PR DESCRIPTION
Updated `build.zig` and `build.zig.zon` to be compatible with zig 0.16.0.