### PR TITLE
function declaration, highlight (nested) types in parameters

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -86,6 +86,24 @@
 (function_declaration
   name: (identifier) @function)
 
+; function declaration, nested types in parameters
+(function_declaration
+  name: (identifier)
+  (parameters
+    (parameter
+      type: (field_expression
+        object: (field_expression)*
+        member: (identifier) @type))))
+
+; function declaration, single types in parameters
+(function_declaration
+  name: (identifier)
+  (parameters
+    (parameter
+      type: (field_expression
+        object: (identifier)
+        member: (identifier) @type))))
+
 ; Modules
 (variable_declaration
   (identifier) @module

--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -95,15 +95,6 @@
         object: (field_expression)*
         member: (identifier) @type))))
 
-; function declaration, single types in parameters
-(function_declaration
-  name: (identifier)
-  (parameters
-    (parameter
-      type: (field_expression
-        object: (identifier)
-        member: (identifier) @type))))
-
 ; Modules
 (variable_declaration
   (identifier) @module


### PR DESCRIPTION
Add highlighting of single and nested types in the parameters of a function declaration.

Example code for testing review:
```zig
const std = @import("std");
const Result = struct { a: []u8 };

pub fn subprocess(io: std.Io, allocator: std.mem.Allocator) !Result {
//------------------------^
//-------------------------------------------^---^
    _ = io;
    _ = allocator;
}
```
